### PR TITLE
CAP Java 2.0

### DIFF
--- a/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
+++ b/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
@@ -30,22 +30,28 @@ When deploying an application to Cloud Foundry, you can use a manifest to descri
 2. Add the following code to the newly created file and make sure you **Save** the file.
 
     ```YAML
-    ---
-    applications:
-    - name: bookstore
-      path: srv/target/bookstore-exec.jar
-      random-route: true
-      services:
-      - bookstore-hana
+        ---
+        applications:
+        - name: bookstore
+        path: srv/target/bookstore-exec.jar
+        random-route: true
+        buildpacks:
+        - java_buildpack
+        env: 
+            JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+ }}'
+            JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
+            SPRING_PROFILES_ACTIVE: cloud
+        services:
+        - bookstore-hana
     ```
 
-The manifest describes the name of the application and the path where the application archive can be found. Spring Boot applications can be deployed from a single JAR archive, which is what you are making use of here.
+The manifest describes the name of the application, the path where the application archive can be found and runtime type. In this tutorial Java Buildpack is used to deploy Spring Boot application from a single JAR archive using Java 17 JRE, which is what you are making use of here.
 
 The route of the application, meaning the HTTP endpoint where it will be available, will be randomized to prevent clashes with other application routes.
 
 The name of SAP HANA service instance you created in the previous tutorial is used here under the services section (`bookstore-hana`).
 
-When your application will be deployed to SAP BTP, it will use this database to store data instead of the in-memory database. In the previous tutorial you added the additional Java system property `-Dspring-boot.run.profiles=cloud` to your application to ensure that. When deploying the application to Cloud Foundry this is done automatically for you by the Cloud Foundry Java Buildpack.
+When your application will be deployed to SAP BTP, it will use this database to store data instead of the in-memory database. In the previous tutorial you added the additional Java system property `-Dspring-boot.run.profiles=cloud` to your application to ensure that. When deploying the application to Cloud Foundry this is via environment variable `SPRING_PROFILES_ACTIVE`.
 
 
 ### Enable application for Cloud Foundry

--- a/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
+++ b/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
@@ -45,7 +45,7 @@ When deploying an application to Cloud Foundry, you can use a manifest to descri
         - bookstore-hana
     ```
 
-The manifest describes the name of the application, the path where the application archive can be found and runtime type. In this tutorial Java Buildpack is used to deploy Spring Boot application from a single JAR archive using Java 17 JRE.
+The manifest describes the name of the application, the path where the application archive can be found and runtime type. In this tutorial Java Buildpack is used to deploy Spring Boot application from a single JAR archive using Java 17.
 
 The route of the application, meaning the HTTP endpoint where it will be available, will be randomized to prevent clashes with other application routes.
 

--- a/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
+++ b/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
@@ -51,7 +51,7 @@ The route of the application, meaning the HTTP endpoint where it will be availab
 
 The name of SAP HANA service instance you created in the previous tutorial is used here under the services section (`bookstore-hana`).
 
-When your application will be deployed to SAP BTP, it will use this database to store data instead of the in-memory database. In the previous tutorial you added the additional Java system property `-Dspring-boot.run.profiles=cloud` to your application to ensure that. When deploying the application to Cloud Foundry this is via environment variable `SPRING_PROFILES_ACTIVE`.
+When your application will be deployed to SAP BTP, it will use this database to store data instead of the in-memory database. In the previous tutorial you added the additional Java system property `-Dspring-boot.run.profiles=cloud` to your application to ensure that. When deploying the application to Cloud Foundry this is set with environment variable `SPRING_PROFILES_ACTIVE`.
 
 
 ### Enable application for Cloud Foundry

--- a/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
+++ b/tutorials/cp-cap-java-deploy-cf/cp-cap-java-deploy-cf.md
@@ -45,7 +45,7 @@ When deploying an application to Cloud Foundry, you can use a manifest to descri
         - bookstore-hana
     ```
 
-The manifest describes the name of the application, the path where the application archive can be found and runtime type. In this tutorial Java Buildpack is used to deploy Spring Boot application from a single JAR archive using Java 17 JRE, which is what you are making use of here.
+The manifest describes the name of the application, the path where the application archive can be found and runtime type. In this tutorial Java Buildpack is used to deploy Spring Boot application from a single JAR archive using Java 17 JRE.
 
 The route of the application, meaning the HTTP endpoint where it will be available, will be randomized to prevent clashes with other application routes.
 

--- a/tutorials/cp-cap-java-hana-db/cp-cap-java-hana-db.md
+++ b/tutorials/cp-cap-java-hana-db/cp-cap-java-hana-db.md
@@ -65,7 +65,7 @@ First you need to create and initialize an SAP HANA database schema in SAP BTP. 
 
 You first need to provision your SAP HANA Cloud instance, which is a prerequisite to later on create a SAP HANA HDI Container to deploy your database artifacts to.
 
-1. Follow the tutorial [Provision an Instance of SAP HANA Cloud](hana-cloud-mission-trial-2). Use `bookstore-db` as the name of your database and make sure to allow access to your SAP HANA Cloud from all IPs.
+1. Follow the tutorial [Provision an Instance of SAP HANA Cloud](hana-cloud-mission-trial-2). Use `bookstore-db` as the name of your database. Make sure to allow access to your SAP HANA Cloud from all IPs and that instance of the SAP HANA you have created is mapped to your subaccount and space where you working with this tutorial.
 
 
 

--- a/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
+++ b/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
@@ -126,7 +126,7 @@ Open your application in the browser. Using the links on the welcome page you ca
 
 To test the secure endpoints of your application, you need a REST client like [Postman](https://www.postman.com/downloads) that supports OAuth 2.0 authentication with type **Authorization Code**.
 
-> Postman may behave differently, when you use SSO to log in to SAP BTP or to a custom identity provider. The following steps assume that you use a Trial account without SSO with the default SAP identity provider.
+> Postman may behave differently, when you use SSO to log in to SAP BTP or a custom identity provider. The following steps assume that you use a Trial account without SSO with the default SAP identity provider.
 
 1. To use the `AdminService`, you need to assign yourself to the role collection `BookStore_Administrators` that was defined in the `xs-security.json` file. To assign this role collection to your user you need to navigate to the **Security** **&rarr;** **Role Collections** section of your SAP BTP subaccount. Select the `BookStore_Administrators` role collection and choose **Edit**. Enter your email address in the **ID** and **E-Mail** field and choose **Save**.
 

--- a/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
+++ b/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
@@ -70,7 +70,7 @@ The XSUAA security descriptor that describes the roles for your application can 
 
     > You added the name of your application in the attribute `xsappname` and declared a role collection to which you can assign users later.
 
-    > The value of the last attribute "oauth2-configuration" depends on the data center where your account is deployed. Check the API URL returned by the command `cf target` and change data center ID in the value `https://*.cfapps.**us10-001**.hana.ondemand.com/**` accordingly.
+    > The value of the last attribute "oauth2-configuration" depends on the landscape where your account is deployed. Check the API URL returned by the command `cf target` and change data center ID in the value `https://*.cfapps.**us10-001**.hana.ondemand.com/**` accordingly.
 
 4. Open the `manifest.yml` file and add the line `bookstore-xsuaa` under the `services` so that the result looks like this:
 

--- a/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
+++ b/tutorials/cp-cap-java-security-cf/cp-cap-java-security-cf.md
@@ -61,23 +61,34 @@ The XSUAA security descriptor that describes the roles for your application can 
           "description": "BookStore Administrators",
           "role-template-references": ["$XSAPPNAME.Administrators"]
         }
-      ]
+      ],
+      "oauth2-configuration": {
+        "redirect-uris": ["https://*.cfapps.us10-001.hana.ondemand.com/**"]
+      }
     }
     ```
 
     > You added the name of your application in the attribute `xsappname` and declared a role collection to which you can assign users later.
 
+    > The value of the last attribute "oauth2-configuration" depends on the data center where your account is deployed. Check the API URL returned by the command `cf target` and change data center ID in the value `https://*.cfapps.**us10-001**.hana.ondemand.com/**` accordingly.
+
 4. Open the `manifest.yml` file and add the line `bookstore-xsuaa` under the `services` so that the result looks like this:
 
     ```YAML
-    ---
-    applications:
-    - name: bookstore
-      path: srv/target/bookstore-exec.jar
-      random-route: true
-      services:
-      - bookstore-hana
-      - bookstore-xsuaa
+        ---
+        applications:
+        - name: bookstore
+        path: srv/target/bookstore-exec.jar
+        random-route: true
+        buildpacks:
+        - java_buildpack
+        env: 
+            JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+ }}'
+            JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
+            SPRING_PROFILES_ACTIVE: cloud
+        services:
+        - bookstore-hana
+        - bookstore-xsuaa
     ```
 
 With this, your application uses this instance of Authorization and Trust Management Service (XSUAA) to manage authentication of users for your application. You will create the instance with that name in the next step.

--- a/tutorials/cp-cap-java-service-reuse/cp-cap-java-service-reuse.md
+++ b/tutorials/cp-cap-java-service-reuse/cp-cap-java-service-reuse.md
@@ -41,7 +41,7 @@ From the products service that you created in the previous tutorial, we just wan
 
     ```Shell/Bash
     mvn -B archetype:generate -DarchetypeArtifactId=cds-services-archetype -DarchetypeGroupId=com.sap.cds \
-    -DarchetypeVersion=RELEASE -DjdkVersion=11 \
+    -DarchetypeVersion=RELEASE -DjdkVersion=17 \
     -DgroupId=com.sap.cap -DartifactId=bookstore
     ```
 


### PR DESCRIPTION
* Both services are created with Java version set to Java 17
* The `manifest.yaml` is changed so it is now specifies Java 17, disables Spring Boot Auto Configuration (buildpack is quite loud about it being deprecated) and explicitly sets the `cloud` profile for Spring Boot. 
* `xs-security.json` is updated with `"oauth2-configuration"`. In default data center offered for trial accounts it is mandatory. 